### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "fstream": "^1.0.12",
-    "npm": "^6.9.0",
     "tar": "^4.4.10"
   }
 }


### PR DESCRIPTION

Hello jjcooney!

It seems like you have npm as one of your (dev-) dependency in Common.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
